### PR TITLE
Ra 1523 return error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt
 
-case "$result" in *"Error"*)
+case "$result" in *"Error: Radix CLI executed with error"*)
     exit 1
     ;;
 esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo "Kaller radix-cli med parametre"
 sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
+echo "Kopierer resultat til variabel"
 result=$(cat result.txt)
 rm -f result.txt
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "Kaller radix-cli med parametre"
 sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt
 
-case "$result" in *"Error: Radix CLI executed with error"*)
+case "$result" in *"Error: "*)
     exit 1
     ;;
 esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,11 @@ sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt
 
-if [[ "$result" =~ "Error" ]]; then
+case "$result" in *"Error"*)
     echo "Dette er en test på at det virker"
     exit 1
-fi
+    ;;
+esac
 
 echo "Uventet"
 echo ::set-output name=result::$result

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,9 @@ result=$(cat result.txt)
 rm -f result.txt
 
 if [[ $result == *"Error"* ]]; then
+    echo "Dette er en test på at det virker"
     exit 1
 fi
 
+echo "Uventet"
 echo ::set-output name=result::$result

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,8 @@ sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt
 
+if [[ $result == *"Error"* ]]; then
+    exit 1
+fi
+
 echo ::set-output name=result::$result

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
-echo "Resultat kopiert til variabel fra fil"
 rm -f result.txt
+
+echo "-----------------------------------------"
+echo "$result"
+echo "-----------------------------------------"
 
 if [[ "$result" == *"Error"* ]]; then
     echo "Dette er en test på at det virker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt
 
-case "$result" in *"Error: "*)
+case "$result" in *"Error: Radix CLI executed with error"*)
     exit 1
     ;;
 esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
-echo "Kopierer resultat til variabel"
 result=$(cat result.txt)
+echo "Resultat kopiert til variabel fra fil"
 rm -f result.txt
 
-if [[ $result == *"Error"* ]]; then
+if [[ "$result" == *"Error"* ]]; then
     echo "Dette er en test på at det virker"
     exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,8 @@ result=$(cat result.txt)
 rm -f result.txt
 
 case "$result" in *"Error"*)
-    echo "Dette er en test på at det virker"
     exit 1
     ;;
 esac
 
-echo "Uventet"
 echo ::set-output name=result::$result

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,11 +3,7 @@ sh -c "rx --token-environment --await-reconcile $*" 2>&1 | tee result.txt
 result=$(cat result.txt)
 rm -f result.txt
 
-echo "-----------------------------------------"
-echo "$result"
-echo "-----------------------------------------"
-
-if [[ "$result" == *"Error"* ]]; then
+if [[ "$result" =~ "Error" ]]; then
     echo "Dette er en test på at det virker"
     exit 1
 fi


### PR DESCRIPTION
If you decide to go for my suggestion, I suggest you handle the release process. That is:

- The related CLI changes are merged to master
- You release a new latest version of the CLI
- You merge the radix-github-actions to master

In this you could also consider having a versioning scheme of the radix-github-actions. Typically users would use the action like this:

```yaml
      - name: Deploy API on Radix
        uses: equinor/radix-github-actions@master
```

If you have a versioning scheme then some user may use v1 like this:

```yaml
      - name: Deploy API on Radix
        uses: equinor/radix-github-actions@v1
```

Then you could introduce a v2 without breaking v1 for users using that. In this case it may not be that relevant.

Before change users would get a successful step, even though the CLI fails:

![image](https://user-images.githubusercontent.com/10051649/89537065-13f6ee80-d7f9-11ea-89d0-b4ce6b59fb0b.png)

After the change we look for the standard error provided by the cli (see https://github.com/equinor/radix-cli/pull/13 for related change). It would look like this to the user:

![image](https://user-images.githubusercontent.com/10051649/89537227-4f91b880-d7f9-11ea-8705-b355c800d9a1.png)
