### PR TITLE
fix: migrate to Environment Files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ case "$result" in *"Error: Radix CLI executed with error"*)
     ;;
 esac
 
-echo ::set-output name=result::$result
+echo result=$result >> $GITHUB_OUTPUT


### PR DESCRIPTION
The set-output command is deprecated, and will stop working 1st June 2023

- Ref:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- Fix:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

- Warning from Action Output:
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/