### PR TITLE
chore: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
     - master
+permissions:
+  contents: read
 jobs:
   build:
     name: Verify Code Generation


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/radix-github-actions/security/code-scanning/2](https://github.com/equinor/radix-github-actions/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block for the workflow or for each job, limiting the `GITHUB_TOKEN` to the minimum required scopes. Since this workflow only checks out code and runs Node/biome/lint commands without publishing artifacts or modifying repository state, `contents: read` is a safe minimal permission.

The best fix without changing existing functionality is to add a root-level `permissions:` block (applies to all jobs that don’t override it) right after the `name:` or `on:` section in `.github/workflows/pr.yml`. We’ll set `contents: read`, which is sufficient for `actions/checkout@v4` to fetch the repository. No additional imports or methods are needed because this is a YAML configuration change only, and both `build` and `lint` jobs will automatically inherit the restricted permissions.

Concretely: in `.github/workflows/pr.yml`, between the `on:` block (lines 2–5) and `jobs:` (line 6), add:

```yaml
permissions:
  contents: read
```

This satisfies CodeQL’s recommendation and applies least-privilege permissions to both `build` and `lint` jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
